### PR TITLE
Add direct SQL query utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - JSON-based workflow with optional SQL integration
 - Built with Flask and Bootstrap 5
 - Simple HTTP endpoint for filtering and querying table rows
+- Command line script for running direct SQL queries
 
 ---
 
@@ -57,6 +58,14 @@ Use the `/search/<filename>` endpoint to filter or search rows:
 curl "http://127.0.0.1:5000/search/ASTORBASE__BoltsDiameters.json?q=20"
 curl "http://127.0.0.1:5000/search/ASTORBASE__BoltDefinition.json?Diameter=20&Name=Hex"
 ```
+
+### Running Direct SQL Queries
+You can query your Advance Steel databases directly using `sql_query.py`:
+
+```bash
+python sql_query.py -d ASTORBASE "SELECT TOP 5 * FROM BoltDefinition"
+```
+Use the `-o json` option to output results as JSON.
 
 ## 📋 Roadmap
 - ✔️ Tabbed UI for bolts and anchors

--- a/sql_query.py
+++ b/sql_query.py
@@ -1,0 +1,77 @@
+# sql_query.py
+"""Run arbitrary SQL queries against the configured server."""
+
+import argparse
+import json
+import pyodbc
+from typing import List, Dict, Optional, Any
+from config import DB_CONFIG
+
+
+def connect_sql_server():
+    """Connect to the SQL Server using settings from config.py."""
+    conn_str = (
+        f"DRIVER={{{DB_CONFIG['driver']}}};"
+        f"SERVER={DB_CONFIG['server']};"
+        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
+    )
+    print(f"🔌 Connecting to {DB_CONFIG['server']}...")
+    conn = pyodbc.connect(conn_str, autocommit=True)
+    print("✅ Connected successfully.")
+    return conn
+
+
+def run_query(cursor, query: str, database: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Execute a SQL query and return results as a list of dicts."""
+    if database:
+        cursor.execute(f"USE [{database}]")
+    cursor.execute(query)
+    if cursor.description is None:
+        return []
+    columns = [col[0] for col in cursor.description]
+    rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+    return rows
+
+
+def format_table(rows: List[Dict[str, Any]]) -> str:
+    if not rows:
+        return "No results."
+    columns = list(rows[0].keys())
+    widths = {c: len(c) for c in columns}
+    for row in rows:
+        for c in columns:
+            widths[c] = max(widths[c], len(str(row[c])))
+    header = " | ".join(c.ljust(widths[c]) for c in columns)
+    sep = "-+-".join("-" * widths[c] for c in columns)
+    lines = [header, sep]
+    for row in rows:
+        lines.append(" | ".join(str(row[c]).ljust(widths[c]) for c in columns))
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a direct SQL query.")
+    parser.add_argument("query", help="SQL statement to execute")
+    parser.add_argument("-d", "--database", help="Database to USE before executing")
+    parser.add_argument(
+        "-o",
+        "--output",
+        choices=["table", "json"],
+        default="table",
+        help="Output format",
+    )
+    args = parser.parse_args()
+
+    conn = connect_sql_server()
+    cur = conn.cursor()
+    results = run_query(cur, args.query, args.database)
+    conn.close()
+
+    if args.output == "json":
+        print(json.dumps(results, indent=2, ensure_ascii=False))
+    else:
+        print(format_table(results))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include a command line tool `sql_query.py` to run arbitrary SQL
- document new script and update features list

## Testing
- `python -m py_compile sql_query.py`
- `python -m py_compile app.py config.py sql_dump.py utils/json_handler.py utils/search_utils.py`
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6859c4d706148324bce710aad963bae4