### PR TITLE
Add Advance Steel version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@
    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
    pip install -r requirements.txt
    ```
-3. **Run the app**
+3. **Choose your Advance Steel version**
+   Edit `config.py` and set `ADVANCE_STEEL_VERSION` to one of `2026`, `2025`, `2024`, or `2023`.
+
+4. **Run the app**
    ```bash
    python app.py
    ```

--- a/config.py
+++ b/config.py
@@ -1,6 +1,19 @@
 # config.py
+"""Configuration for connecting to Advance Steel local databases."""
+
+# Supported Advance Steel versions. Select the one installed on this machine.
+ADVANCE_STEEL_VERSION = 2025  # choose from 2026, 2025, 2024, or 2023
+
+SUPPORTED_VERSIONS = {2026, 2025, 2024, 2023}
+
+if ADVANCE_STEEL_VERSION not in SUPPORTED_VERSIONS:
+    raise ValueError(
+        f"Unsupported Advance Steel version: {ADVANCE_STEEL_VERSION}. "
+        f"Supported versions are: {sorted(SUPPORTED_VERSIONS)}"
+    )
+
 DB_CONFIG = {
-    'server': r'(LocalDB)\ADVANCESTEEL2025',
+    'server': rf'(LocalDB)\ADVANCESTEEL{ADVANCE_STEEL_VERSION}',
     'trusted_connection': 'yes',
     'driver': 'ODBC Driver 17 for SQL Server'
 }


### PR DESCRIPTION
## Summary
- allow selecting Advance Steel version from 2026-2023 in `config.py`
- update setup instructions in README

## Testing
- `python -m py_compile` on all Python files

------
https://chatgpt.com/codex/tasks/task_e_6859c709de98832487d48dd1b6c7eae5