### PR TITLE
Add read-only mode and simple SQL browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - Built with Flask and Bootstrap 5
 - Simple HTTP endpoint for filtering and querying table rows
 - Command line script for running direct SQL queries
+- Optional SQL browser with simple query interface
+- Development read-only mode to prevent accidental changes
 
 ---
 
@@ -36,6 +38,8 @@
    ```
 3. **Choose your Advance Steel version**
    Edit `config.py` and set `ADVANCE_STEEL_VERSION` to one of `2026`, `2025`, `2024`, or `2023`.
+   You can also enable or disable `READ_ONLY` mode in this file. When enabled the
+   web interface will prevent saving changes.
 
 4. **Run the app**
    ```bash
@@ -69,6 +73,10 @@ You can query your Advance Steel databases directly using `sql_query.py`:
 python sql_query.py -d ASTORBASE "SELECT TOP 5 * FROM BoltDefinition"
 ```
 Use the `-o json` option to output results as JSON.
+
+### SQL Browser
+Navigate to `/sql` in the running app to view available tables and run simple
+queries through the web interface.
 
 ## 📋 Roadmap
 - ✔️ Tabbed UI for bolts and anchors

--- a/app.py
+++ b/app.py
@@ -1,22 +1,38 @@
 # app.py
 from flask import Flask, render_template, request, redirect, url_for, jsonify
 import os
+import pyodbc
 from utils.json_handler import load_json, save_json
 from utils.search_utils import filter_data, query_data
+from config import DB_CONFIG, DEFAULT_DATABASE, READ_ONLY
 
 app = Flask(__name__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
+
+def connect_sql_server(database: str = DEFAULT_DATABASE):
+    """Return a connection object to the configured SQL Server."""
+    conn_str = (
+        f"DRIVER={{{DB_CONFIG['driver']}}};"
+        f"SERVER={DB_CONFIG['server']};"
+        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
+    )
+    conn = pyodbc.connect(conn_str, autocommit=True)
+    cursor = conn.cursor()
+    if database:
+        cursor.execute(f"USE [{database}]")
+    return conn, cursor
+
 @app.route('/')
 def index():
     files = [f for f in os.listdir(DATA_DIR) if f.endswith('.json')]
-    return render_template('index.html', files=files)
+    return render_template('index.html', files=files, read_only=READ_ONLY)
 
 @app.route('/view/<filename>')
 def view_table(filename):
     path = os.path.join(DATA_DIR, filename)
     table_data = load_json(path)
-    return render_template('edit_table.html', filename=filename, table=table_data["data"])
+    return render_template('edit_table.html', filename=filename, table=table_data["data"], read_only=READ_ONLY)
 
 
 @app.route('/search/<filename>')
@@ -36,12 +52,50 @@ def search_table(filename):
 
     return jsonify(table_data)
 
-@app.route('/save/<filename>', methods=['POST'])
-def save_table(filename):
-    updated_data = request.form.get('json_data')
-    path = os.path.join(DATA_DIR, filename)
-    save_json(path, updated_data)
-    return redirect(url_for('view_table', filename=filename))
+if not READ_ONLY:
+    @app.route('/save/<filename>', methods=['POST'])
+    def save_table(filename):
+        updated_data = request.form.get('json_data')
+        path = os.path.join(DATA_DIR, filename)
+        save_json(path, updated_data)
+        return redirect(url_for('view_table', filename=filename))
+
+
+@app.route('/sql')
+def list_sql_tables():
+    """List available tables in the default database."""
+    tables = []
+    error = None
+    try:
+        conn, cur = connect_sql_server()
+        cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE'")
+        tables = [row[0] for row in cur.fetchall()]
+        conn.close()
+    except Exception as e:
+        error = str(e)
+    return render_template('sql_tables.html', tables=tables, error=error)
+
+
+@app.route('/sql/<table_name>', methods=['GET', 'POST'])
+def query_sql_table(table_name):
+    """Simple interface to run a SELECT query against a table."""
+    results = None
+    error = None
+    query = request.form.get('query') if request.method == 'POST' else f"SELECT TOP 100 * FROM [{table_name}]"
+    if request.method == 'POST':
+        try:
+            conn, cur = connect_sql_server()
+            cur.execute(query)
+            if cur.description:
+                columns = [c[0] for c in cur.description]
+                rows = [dict(zip(columns, r)) for r in cur.fetchall()]
+                results = rows
+            else:
+                results = []
+            conn.close()
+        except Exception as e:
+            error = str(e)
+    return render_template('sql_query.html', table_name=table_name, query=query, results=results, error=error)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/config.py
+++ b/config.py
@@ -17,3 +17,10 @@ DB_CONFIG = {
     'trusted_connection': 'yes',
     'driver': 'ODBC Driver 17 for SQL Server'
 }
+
+# Default database used by the web SQL interface
+DEFAULT_DATABASE = 'ASTORBASE'
+
+# Enable development read-only mode. When True, editing routes are disabled
+# and the UI will not allow saving changes.
+READ_ONLY = True

--- a/templates/edit_table.html
+++ b/templates/edit_table.html
@@ -19,8 +19,10 @@
 <body class="p-4">
   <div class="container">
     <h1>{{ filename }}</h1>
-    <textarea id="json_data" class="form-control" rows="25">{{ table | tojson(indent=2) }}</textarea>
+    <textarea id="json_data" class="form-control" rows="25" {% if read_only %}readonly{% endif %}>{{ table | tojson(indent=2) }}</textarea>
+    {% if not read_only %}
     <button class="btn btn-success mt-3" onclick="saveTable()">💾 Save Changes</button>
+    {% endif %}
     <a class="btn btn-secondary mt-3" href="/">← Back</a>
   </div>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,12 @@
 <body class="p-4">
   <div class="container">
     <h1>BoltForge Web</h1>
+    {% if read_only %}
+      <div class="alert alert-warning" role="alert">
+        Read-only mode enabled. Editing is disabled.
+      </div>
+    {% endif %}
+    <p><a href="{{ url_for('list_sql_tables') }}">SQL Browser</a></p>
     <ul class="list-group mt-4">
       {% for file in files %}
         <li class="list-group-item">

--- a/templates/sql_query.html
+++ b/templates/sql_query.html
@@ -1,0 +1,27 @@
+<!-- templates/sql_query.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Query {{ table_name }}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1>{{ table_name }}</h1>
+    {% if error %}
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <textarea name="query" class="form-control" rows="5">{{ query }}</textarea>
+      </div>
+      <button class="btn btn-primary" type="submit">Run</button>
+      <a class="btn btn-secondary" href="{{ url_for('list_sql_tables') }}">← Back</a>
+    </form>
+    {% if results is not none %}
+      <pre class="mt-3"><code>{{ results | tojson(indent=2) }}</code></pre>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/sql_tables.html
+++ b/templates/sql_tables.html
@@ -1,0 +1,23 @@
+<!-- templates/sql_tables.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>SQL Tables</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+  <div class="container">
+    <h1>SQL Tables</h1>
+    {% if error %}
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    <ul class="list-group mt-4">
+      {% for table in tables %}
+        <li class="list-group-item"><a href="{{ url_for('query_sql_table', table_name=table) }}">{{ table }}</a></li>
+      {% endfor %}
+    </ul>
+    <a class="btn btn-secondary mt-3" href="/">← Back</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support READ_ONLY dev mode
- integrate new SQL browser interface
- list SQL tables and run queries from the UI
- document new features and settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ca082da48324b3ac7ad28373afd6