### PR TITLE
Refactor SQL helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,28 +2,13 @@
 from flask import Flask, render_template, request, redirect, url_for, jsonify
 import os
 import json
-import pyodbc
 from utils.json_handler import load_json, save_json
 from utils.search_utils import filter_data, query_data
-from config import DB_CONFIG, DEFAULT_DATABASE, READ_ONLY, SQL_DIRECT_MODE
+from config import DEFAULT_DATABASE, READ_ONLY, SQL_DIRECT_MODE
+from utils.db import connect_sql_server
 
 app = Flask(__name__)
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
-
-
-def connect_sql_server(database: str = DEFAULT_DATABASE):
-    """Return a connection object to the configured SQL Server."""
-    conn_str = (
-        f"DRIVER={{{DB_CONFIG['driver']}}};"
-        f"SERVER={DB_CONFIG['server']};"
-        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
-    )
-    conn = pyodbc.connect(conn_str, autocommit=True)
-    cursor = conn.cursor()
-    if database:
-        cursor.execute(f"USE [{database}]")
-    return conn, cursor
-
 
 def parse_sql_path(filename: str):
     """Return (database, table) parsed from a data filename."""

--- a/sql_dump.py
+++ b/sql_dump.py
@@ -2,21 +2,9 @@
 
 import os
 import json
-import pyodbc
-from config import DB_CONFIG
+from utils.db import connect_sql_server
 
 OUTPUT_DIR = "sql_dump"
-
-def connect_sql_server():
-    conn_str = (
-        f"DRIVER={{{DB_CONFIG['driver']}}};"
-        f"SERVER={DB_CONFIG['server']};"
-        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
-    )
-    print(f"🔌 Connecting to {DB_CONFIG['server']}...")
-    conn = pyodbc.connect(conn_str, autocommit=True)
-    print("✅ Connected successfully.")
-    return conn
 
 def get_databases(cursor):
     cursor.execute("SELECT name, database_id FROM sys.databases ORDER BY name")

--- a/sql_query.py
+++ b/sql_query.py
@@ -3,22 +3,8 @@
 
 import argparse
 import json
-import pyodbc
 from typing import List, Dict, Optional, Any
-from config import DB_CONFIG
-
-
-def connect_sql_server():
-    """Connect to the SQL Server using settings from config.py."""
-    conn_str = (
-        f"DRIVER={{{DB_CONFIG['driver']}}};"
-        f"SERVER={DB_CONFIG['server']};"
-        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
-    )
-    print(f"🔌 Connecting to {DB_CONFIG['server']}...")
-    conn = pyodbc.connect(conn_str, autocommit=True)
-    print("✅ Connected successfully.")
-    return conn
+from utils.db import connect_sql_server
 
 
 def run_query(cursor, query: str, database: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,21 @@
+# utils/db.py
+"""Helper for connecting to the configured SQL Server."""
+
+import pyodbc
+from typing import Tuple
+
+from config import DB_CONFIG, DEFAULT_DATABASE
+
+
+def connect_sql_server(database: str = DEFAULT_DATABASE) -> Tuple[pyodbc.Connection, pyodbc.Cursor]:
+    """Return a connection and cursor to the configured SQL Server."""
+    conn_str = (
+        f"DRIVER={{{DB_CONFIG['driver']}}};"
+        f"SERVER={DB_CONFIG['server']};"
+        f"Trusted_Connection={DB_CONFIG['trusted_connection']};"
+    )
+    conn = pyodbc.connect(conn_str, autocommit=True)
+    cursor = conn.cursor()
+    if database:
+        cursor.execute(f"USE [{database}]")
+    return conn, cursor


### PR DESCRIPTION
## Summary
- centralize SQL connection in `utils/db.py`
- reuse helper in `app.py`, `sql_query.py`, and `sql_dump.py`

## Testing
- `python3 sql_query.py "SELECT 1"` *(fails: Can't open lib 'ODBC Driver 17 for SQL Server')*
- `python3 sql_dump.py` *(fails: Can't open lib 'ODBC Driver 17 for SQL Server')*

------
https://chatgpt.com/codex/tasks/task_e_6859dcf9dd308324945f71b203bf1804