### PR TITLE
Add pytest tests for utility helpers

### DIFF
--- a/tests/test_json_handler.py
+++ b/tests/test_json_handler.py
@@ -1,0 +1,14 @@
+import json
+from utils.json_handler import load_json, save_json
+
+
+def test_load_save_round_trip(tmp_path):
+    data = {"foo": 123, "bar": [1, 2, 3]}
+    json_string = json.dumps(data)
+    file_path = tmp_path / "sample.json"
+
+    save_json(file_path, json_string)
+    loaded = load_json(file_path)
+
+    assert loaded == data
+

--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+from utils.search_utils import filter_data, query_data
+
+
+sample_rows = [
+    {"id": 1, "name": "Bolt", "size": "M10"},
+    {"id": 2, "name": "Nut", "size": "M12"},
+    {"id": 3, "name": "Washer", "size": "M10"},
+]
+
+
+def test_filter_data_single_match():
+    result = filter_data(sample_rows, id=1)
+    assert result == [{"id": 1, "name": "Bolt", "size": "M10"}]
+
+
+def test_filter_data_multiple_criteria():
+    result = filter_data(sample_rows, size="M10", name="Washer")
+    assert result == [{"id": 3, "name": "Washer", "size": "M10"}]
+
+
+def test_filter_data_no_match():
+    result = filter_data(sample_rows, name="Screw")
+    assert result == []
+
+
+def test_query_data_finds_term_case_insensitive():
+    result = query_data(sample_rows, "nu")
+    assert result == [{"id": 2, "name": "Nut", "size": "M12"}]
+
+
+def test_query_data_returns_multiple_rows():
+    result = query_data(sample_rows, "m10")
+    assert result == [
+        {"id": 1, "name": "Bolt", "size": "M10"},
+        {"id": 3, "name": "Washer", "size": "M10"},
+    ]
+


### PR DESCRIPTION
## Summary
- add pytest tests for search utilities
- add round-trip test for JSON helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859dd1122bc83249441acfd9c8d9e3f