### PR TITLE
Add deploy.bat for Windows deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
    python app.py
    ```
    Open <http://127.0.0.1:5000> in your browser.
+   On Windows you can run `deploy.bat` to automatically pull the latest
+   changes, activate the virtual environment, and start the app.
 
 ### JSON File Structure
 Place your exported `.json` files in the `data/` directory:

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,0 +1,31 @@
+@echo off
+rem deploy.bat - Update repo, activate venv, and run the app
+
+cd /d "%~dp0"
+
+rem Pull latest changes
+if exist ".git" (
+    echo Pulling latest changes...
+    git pull --ff-only
+) else (
+    echo Not inside a git repository.
+    exit /b 1
+)
+
+rem Activate virtual environment or create it if missing
+if exist "venv\Scripts\activate.bat" (
+    echo Activating existing virtual environment...
+    call "venv\Scripts\activate.bat"
+) else (
+    echo Virtual environment not found. Creating one...
+    python -m venv venv
+    call "venv\Scripts\activate.bat"
+    if exist requirements.txt (
+        pip install -r requirements.txt
+    ) else (
+        pip install flask
+    )
+)
+
+rem Start the Flask application
+python app.py


### PR DESCRIPTION
## Summary
- add `deploy.bat` for Windows users to pull the repo, activate a venv and run the app
- document the batch script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e04d685483248b2d2fa6772da2a0