### PR TITLE
Add dev requirements and pin versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
    python -m venv venv
    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
    pip install -r requirements.txt
+   # Install development dependencies to run the test suite
+   pip install -r requirements-dev.txt
    ```
 3. **Choose your Advance Steel version**
    Edit `config.py` and set `ADVANCE_STEEL_VERSION` to one of `2026`, `2025`, `2024`, or `2023`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development dependencies
+pytest>=7,<8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pyodbc
-Flask
+# Runtime dependencies with versions tested for this project
+pyodbc>=5,<6
+Flask>=2,<3


### PR DESCRIPTION
## Summary
- pin runtime dependency versions in `requirements.txt`
- add a new `requirements-dev.txt` for pytest
- document installing runtime and dev dependencies in the README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1e41c60c8324bd1fb443634f0c86