### PR TITLE
Add advanced filtering options

### DIFF
--- a/tests/test_search_utils.py
+++ b/tests/test_search_utils.py
@@ -24,6 +24,32 @@ def test_filter_data_no_match():
     assert result == []
 
 
+def test_filter_data_numeric_gt():
+    result = filter_data(sample_rows, id__gt=1)
+    assert result == [
+        {"id": 2, "name": "Nut", "size": "M12"},
+        {"id": 3, "name": "Washer", "size": "M10"},
+    ]
+
+
+def test_filter_data_numeric_lt():
+    result = filter_data(sample_rows, id__lt=3)
+    assert result == [
+        {"id": 1, "name": "Bolt", "size": "M10"},
+        {"id": 2, "name": "Nut", "size": "M12"},
+    ]
+
+
+def test_filter_data_case_insensitive():
+    result = filter_data(sample_rows, name="bolt", case_insensitive=True)
+    assert result == [{"id": 1, "name": "Bolt", "size": "M10"}]
+
+
+def test_filter_data_partial_match():
+    result = filter_data(sample_rows, name="ash", partial=True, case_insensitive=True)
+    assert result == [{"id": 3, "name": "Washer", "size": "M10"}]
+
+
 def test_query_data_finds_term_case_insensitive():
     result = query_data(sample_rows, "nu")
     assert result == [{"id": 2, "name": "Nut", "size": "M12"}]


### PR DESCRIPTION
## Summary
- enhance `filter_data` to support numeric comparisons
- add optional case-insensitive and partial matching
- test new comparison and string matching behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1e4dbc5c83248dd353fc26d651ea