### PR TITLE
Remove JSON data usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔩 AdvSteel FastenSuite
 
-**AdvSteel FastenSuite** is a lightweight Flask application for browsing and editing Advance Steel fastener data. It provides a clean web interface for working with your exported `.json` files (or SQL data) without the pain of Management Tools.
+**AdvSteel FastenSuite** is a lightweight Flask application for browsing and editing Advance Steel fastener data. It provides a clean web interface that works directly with your SQL data without the pain of Management Tools.
 
 ---
 
@@ -14,13 +14,13 @@
   - `BoltsDistances`
   - `AnchorsDefinition`
   - `AnchorsClass`, `AnchorsStandard`, and more
-- JSON-based workflow with optional SQL integration
+- Direct SQL workflow without requiring JSON exports
 - Built with Flask and Bootstrap 5
 - Simple HTTP endpoint for filtering and querying table rows
 - Command line script for running direct SQL queries
 - Optional SQL browser with simple query interface
 - Development read-only mode to prevent accidental changes
-- SQL direct mode for editing tables without JSON exports
+- Edit tables directly in SQL
 
 ---
 
@@ -43,7 +43,6 @@
    Edit `config.py` and set `ADVANCE_STEEL_VERSION` to one of `2026`, `2025`, `2024`, or `2023`.
    You can also enable or disable `READ_ONLY` mode in this file. When enabled the
    web interface will prevent saving changes.
-   Set `SQL_DIRECT_MODE = True` to read and write directly from your SQL Server databases.
 
 4. **Run the app**
    ```bash
@@ -52,17 +51,6 @@
    Open <http://127.0.0.1:5000> in your browser.
    On Windows you can run `deploy.bat` to automatically pull the latest
    changes, activate the virtual environment, and start the app.
-
-### JSON File Structure
-Place your exported `.json` files in the `data/` directory:
-
-```
-/data
-├── ASTORBASE__BoltDefinition.json
-├── ASTORBASE__BoltsDiameters.json
-├── ASTORBASE__AnchorsDefinition.json
-└── ...
-```
 
 ### Querying Tables
 Use the `/search/<filename>` endpoint to filter or search rows:

--- a/config.py
+++ b/config.py
@@ -25,6 +25,3 @@ DEFAULT_DATABASE = 'ASTORBASE'
 # and the UI will not allow saving changes.
 READ_ONLY = True
 
-# When enabled, the web interface loads and saves data directly from the SQL
-# databases instead of the JSON files in the data directory.
-SQL_DIRECT_MODE = False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,8 @@ import pytest
 import config
 import app as app_module
 
+TABLE_ROWS = [(1, "Alice"), (2, "Bob")]
+
 
 def fake_connect_sql_server(database=config.DEFAULT_DATABASE):
     class MockCursor:
@@ -12,13 +14,19 @@ def fake_connect_sql_server(database=config.DEFAULT_DATABASE):
             self.description = []
             self.results = []
 
-        def execute(self, query):
+        def execute(self, query, params=None):
             if "INFORMATION_SCHEMA.TABLES" in query:
                 self.description = [("TABLE_NAME",)]
                 self.results = [("MockTable",)]
-            else:
+            elif query.startswith("SELECT *"):
                 self.description = [("id",), ("name",)]
-                self.results = [(1, "Alice"), (2, "Bob")]
+                self.results = TABLE_ROWS
+            elif query.startswith("DELETE"):
+                TABLE_ROWS.clear()
+                self.description = []
+                self.results = []
+            elif query.startswith("INSERT"):
+                TABLE_ROWS.append(tuple(params))
 
         def fetchall(self):
             return self.results
@@ -30,55 +38,48 @@ def fake_connect_sql_server(database=config.DEFAULT_DATABASE):
     return MockConn(), MockCursor()
 
 
-def make_client(tmp_path, monkeypatch, read_only=True):
+def make_client(monkeypatch, read_only=True):
     monkeypatch.setattr(config, "READ_ONLY", read_only)
-    monkeypatch.setattr(config, "SQL_DIRECT_MODE", False)
     importlib.reload(app_module)
-    monkeypatch.setattr(app_module, "DATA_DIR", tmp_path)
     monkeypatch.setattr(app_module, "connect_sql_server", fake_connect_sql_server)
 
-    sample_data = {"data": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}]}
-    file_path = tmp_path / "ASTORBASE__Sample.json"
-    with open(file_path, "w", encoding="utf-8") as f:
-        json.dump(sample_data, f)
-
     client = app_module.app.test_client()
-    return client, file_path
+    return client, "ASTORBASE__MockTable.json"
 
 
 @pytest.fixture
-def client_ro(tmp_path, monkeypatch):
-    return make_client(tmp_path, monkeypatch, read_only=True)
+def client_ro(monkeypatch):
+    return make_client(monkeypatch, read_only=True)
 
 
 @pytest.fixture
-def client_rw(tmp_path, monkeypatch):
-    return make_client(tmp_path, monkeypatch, read_only=False)
+def client_rw(monkeypatch):
+    return make_client(monkeypatch, read_only=False)
 
 
 def test_index_lists_files_and_read_only(client_ro):
-    client, file_path = client_ro
+    client, file_name = client_ro
     resp = client.get("/")
     text = resp.get_data(as_text=True)
     assert resp.status_code == 200
-    assert file_path.name in text
+    assert file_name in text
     assert "Read-only mode" in text
 
 
 def test_view_table_displays_rows(client_ro):
-    client, file_path = client_ro
-    resp = client.get(f"/view/{file_path.name}")
+    client, file_name = client_ro
+    resp = client.get(f"/view/{file_name}")
     text = resp.get_data(as_text=True)
     assert resp.status_code == 200
     assert "Alice" in text
 
 
 def test_search_endpoint(client_ro):
-    client, file_path = client_ro
-    resp = client.get(f"/search/{file_path.name}?q=Ali")
+    client, file_name = client_ro
+    resp = client.get(f"/search/{file_name}?q=Ali")
     assert resp.status_code == 200
     assert resp.get_json() == [{"id": 1, "name": "Alice"}]
-    resp = client.get(f"/search/{file_path.name}?name=Bob")
+    resp = client.get(f"/search/{file_name}?name=Bob")
     assert resp.get_json() == [{"id": 2, "name": "Bob"}]
 
 
@@ -93,20 +94,19 @@ def test_sql_routes_use_mock_db(client_ro):
 
 
 def test_save_route_disabled_in_read_only(client_ro):
-    client, file_path = client_ro
-    resp = client.post(f"/save/{file_path.name}", data={"json_data": "[]"})
+    client, file_name = client_ro
+    resp = client.post(f"/save/{file_name}", data={"json_data": "[]"})
     assert resp.status_code == 404
 
 
-def test_save_updates_file_when_allowed(client_rw):
-    client, file_path = client_rw
-    new_rows = [{"id": 10}]
+def test_save_updates_table_when_allowed(client_rw):
+    client, file_name = client_rw
+    new_rows = [{"id": 10, "name": "Test"}]
     resp = client.post(
-        f"/save/{file_path.name}",
+        f"/save/{file_name}",
         data={"json_data": json.dumps(new_rows)},
         follow_redirects=False,
     )
     assert resp.status_code == 302
-    with open(file_path, "r", encoding="utf-8") as f:
-        saved = json.load(f)
-    assert saved["data"] == new_rows
+    resp = client.get(f"/view/{file_name}")
+    assert "Test" in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- always use SQL for data access
- drop SQL_DIRECT_MODE config option
- update tests accordingly
- clarify README to remove JSON workflow references

## Testing
- `pip install flask --quiet`
- `pip install pyodbc --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c207034508324b199f332abf9a79c