### PR TITLE
Add database backup utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ exploring the Advance Steel databases and are handy for maintenance tasks:
   export filtered rows interactively.
 - `check_db_connection.py` – verify that the settings in `config.py` can reach
   your local SQL Server instance.
+- `backup_db.py` – create a timestamped backup of `AstorBase.mdf` and `AstorBase.ldf`
+  as recommended in the bolt study guide.
 
 ### Running Tests
 After installing the development dependencies you can run the

--- a/backup_db.py
+++ b/backup_db.py
@@ -1,0 +1,54 @@
+import os
+from pathlib import Path
+import shutil
+import datetime
+
+from config import ADVANCE_STEEL_VERSION
+
+DEFAULT_DATA_DIR = Path(
+    f"C:/ProgramData/Autodesk/Advance Steel {ADVANCE_STEEL_VERSION}/USA/Steel/Data"
+)
+
+
+def get_data_dir() -> Path:
+    """Return the Advance Steel data directory."""
+    return Path(os.environ.get("ADVSTEEL_DATA_DIR", DEFAULT_DATA_DIR))
+
+
+def backup_database(data_dir: Path | None = None, out_dir: str | Path = "backups") -> Path:
+    """Backup AstorBase MDF and LDF files to a timestamped folder.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory containing AstorBase.mdf and AstorBase.ldf. If None, uses
+        ``get_data_dir()``.
+    out_dir:
+        Directory where backups are created.
+
+    Returns
+    -------
+    Path
+        Path to the created backup directory.
+    """
+    data_dir = Path(data_dir) if data_dir else get_data_dir()
+    if not data_dir.exists():
+        raise FileNotFoundError(f"Data directory not found: {data_dir}")
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    backup_dir = Path(out_dir) / f"{ADVANCE_STEEL_VERSION}_{timestamp}"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    for name in ["AstorBase.mdf", "AstorBase.ldf"]:
+        src = data_dir / name
+        if src.exists():
+            shutil.copy2(src, backup_dir / name)
+        else:
+            print(f"Warning: {src} not found")
+
+    return backup_dir
+
+
+if __name__ == "__main__":
+    path = backup_database()
+    print(f"Backup created at: {path}")

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -1,0 +1,29 @@
+import os
+import datetime
+from pathlib import Path
+
+import backup_db
+
+
+def test_get_data_dir_env(monkeypatch):
+    monkeypatch.setenv("ADVSTEEL_DATA_DIR", "/tmp/custom")
+    assert backup_db.get_data_dir() == Path("/tmp/custom")
+
+
+def test_backup_database(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "AstorBase.mdf").write_text("mdf")
+    (data_dir / "AstorBase.ldf").write_text("ldf")
+
+    class FixedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2020, 1, 1, 12, 0, 0)
+
+    monkeypatch.setattr(backup_db.datetime, "datetime", FixedDatetime)
+    backup_path = backup_db.backup_database(data_dir=data_dir, out_dir=tmp_path)
+    expected = tmp_path / f"{backup_db.ADVANCE_STEEL_VERSION}_20200101_120000"
+    assert backup_path == expected
+    assert (backup_path / "AstorBase.mdf").read_text() == "mdf"
+    assert (backup_path / "AstorBase.ldf").read_text() == "ldf"


### PR DESCRIPTION
## Summary
- add a `backup_db.py` script to back up AstorBase MDF/LDF files
- document the new script in README
- test backup logic with pytest

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ece49a12c832491f163f7b24304e3